### PR TITLE
Add moving event for locomotion handling

### DIFF
--- a/Runtime/BaseLocomotionProvider.cs
+++ b/Runtime/BaseLocomotionProvider.cs
@@ -72,6 +72,9 @@ namespace RealityToolkit.Locomotion
         protected virtual void OnDeactivated() { }
 
         /// <inheritdoc />
+        public virtual void OnMoving(LocomotionEventData eventData) { }
+
+        /// <inheritdoc />
         public virtual void OnTeleportTargetRequested(LocomotionEventData eventData) { }
 
         /// <inheritdoc />

--- a/Runtime/ILocomotionService.cs
+++ b/Runtime/ILocomotionService.cs
@@ -3,6 +3,7 @@
 
 using RealityCollective.ServiceFramework.Interfaces;
 using RealityToolkit.Input.Interfaces;
+using RealityToolkit.Locomotion.Movement;
 using RealityToolkit.Locomotion.Teleportation;
 using System;
 using System.Collections.Generic;
@@ -47,6 +48,9 @@ namespace RealityToolkit.Locomotion
         /// Gets a list of currently enabled <see cref="ILocomotionProvider"/>s.
         /// </summary>
         IReadOnlyList<ILocomotionProvider> EnabledLocomotionProviders { get; }
+
+        /// <inheritdoc cref="ILocomotionServiceHandler.OnMoving(LocomotionEventData)"/>
+        event LocomotionEventDelegate Moving;
 
         /// <inheritdoc cref="ILocomotionServiceHandler.OnTeleportTargetRequested(LocomotionEventData)"/>
         event LocomotionEventDelegate TeleportTargetRequested;
@@ -95,6 +99,15 @@ namespace RealityToolkit.Locomotion
         /// </summary>
         /// <param name="locomotionProvider">The disabled <see cref="ILocomotionProvider"/>.</param>
         void OnLocomotionProviderDisabled(ILocomotionProvider locomotionProvider);
+
+        /// <summary>
+        /// Raise a moving event for <see cref="ILocomotionServiceHandler"/>s.
+        /// </summary>
+        /// <param name="freeLocomotionProvider">The <see cref="IFreeLocomotionProvider"/> that is executing the movement.</param>
+        /// <param name="inputSource">The <see cref="IInputSource"/> the <paramref name="freeLocomotionProvider"/> received input from.</param>
+        /// <param name="direction">The direction of movement.</param>
+        /// <param name="speed">The movement speed.</param>
+        void RaiseMoving(IFreeLocomotionProvider freeLocomotionProvider, IInputSource inputSource, Vector3 direction, float speed);
 
         /// <summary>
         /// Raise a teleportation target request event.

--- a/Runtime/ILocomotionServiceHandler.cs
+++ b/Runtime/ILocomotionServiceHandler.cs
@@ -11,6 +11,12 @@ namespace RealityToolkit.Locomotion
     public interface ILocomotionServiceHandler : IEventSystemHandler
     {
         /// <summary>
+        /// Raised when a <see cref="Movement.IFreeLocomotionProvider"/> is executing movement.
+        /// </summary>
+        /// <param name="eventData"><see cref="LocomotionEventData"/> provided.</param>
+        void OnMoving(LocomotionEventData eventData);
+
+        /// <summary>
         /// Raised when a <see cref="Teleportation.ITeleportLocomotionProvider"/> requests a
         /// target location for teleport, but no teleportation has started.
         /// </summary>

--- a/Runtime/LocomotionEventData.cs
+++ b/Runtime/LocomotionEventData.cs
@@ -20,6 +20,16 @@ namespace RealityToolkit.Locomotion
         public ILocomotionProvider LocomotionProvider { get; private set; }
 
         /// <summary>
+        /// The direction of movement.
+        /// </summary>
+        public Vector3 Direction { get; private set; }
+
+        /// <summary>
+        /// The movement speed.
+        /// </summary>
+        public float Speed { get; private set; }
+
+        /// <summary>
         /// The teleport target pose, if any.
         /// </summary>
         public Pose? Pose { get; private set; }
@@ -48,6 +58,21 @@ namespace RealityToolkit.Locomotion
             LocomotionProvider = locomotionProvider;
             Pose = pose;
             Anchor = anchor;
+        }
+
+        /// <summary>
+        /// Used to initialize/reset the event and populate the data.
+        /// </summary>
+        /// <param name="locomotionProvider">The <see cref="ILocomotionProvider"/> the event data is addressed at or coming from.</param>
+        /// /// <param name="inputSource">The <see cref="IInputSource"/> the event originated from.</param>
+        /// <param name="direction">The direction of movement.</param>
+        /// <param name="speed">The movement speed applied.</param>
+        public void Initialize(ILocomotionProvider locomotionProvider, IInputSource inputSource, Vector3 direction, float speed)
+        {
+            BaseInitialize(inputSource);
+            LocomotionProvider = locomotionProvider;
+            Direction = direction;
+            Speed = speed;
         }
 
         /// <summary>

--- a/Runtime/LocomotionProviderEventDriver.cs
+++ b/Runtime/LocomotionProviderEventDriver.cs
@@ -69,6 +69,15 @@ namespace RealityToolkit.Locomotion
         protected virtual void OnDestroy() => LocomotionService?.Unregister(gameObject);
 
         /// <inheritdoc />
+        public virtual void OnMoving(LocomotionEventData eventData)
+        {
+            for (int i = 0; i < LocomotionService.EnabledLocomotionProviders.Count; i++)
+            {
+                LocomotionService.EnabledLocomotionProviders[i].OnMoving(eventData);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void OnTeleportTargetRequested(LocomotionEventData eventData)
         {
             if (InputService.TryGetInputSource(eventData.EventSource.SourceId, out var inputSource))

--- a/Runtime/Movement/SmoothLocomotionProvider.cs
+++ b/Runtime/Movement/SmoothLocomotionProvider.cs
@@ -92,7 +92,10 @@ namespace RealityToolkit.Locomotion.Movement
                 LocomotionService.MovementEnabled &&
                 eventData.InputAction == InputAction)
             {
-                LocomotionService.LocomotionTarget.Move(eventData.InputData, isRunning ? RunningSpeed : Speed);
+                var speed = isRunning ? RunningSpeed : Speed;
+
+                LocomotionService.LocomotionTarget.Move(eventData.InputData, speed);
+                LocomotionService.RaiseMoving(this, eventData.InputSource, eventData.InputData, speed);
             }
         }
     }

--- a/Runtime/Teleportation/TeleportCursor.cs
+++ b/Runtime/Teleportation/TeleportCursor.cs
@@ -116,6 +116,9 @@ namespace RealityToolkit.Locomotion.Teleportation
         }
 
         /// <inheritdoc />
+        public void OnMoving(LocomotionEventData eventData) { }
+
+        /// <inheritdoc />
         public void OnTeleportTargetRequested(LocomotionEventData eventData)
         {
             OnCursorStateChange(CursorStateEnum.Observe);

--- a/Runtime/Teleportation/TeleportInteractor.cs
+++ b/Runtime/Teleportation/TeleportInteractor.cs
@@ -388,7 +388,7 @@ namespace RealityToolkit.Locomotion.Teleportation
 
         #endregion IInputHandler Implementation
 
-        #region ITeleportHandler Implementation
+        #region ILocomotionServiceHandler Implementation
 
         /// <inheritdoc />
         public void OnMoving(LocomotionEventData eventData) { }
@@ -432,6 +432,6 @@ namespace RealityToolkit.Locomotion.Teleportation
             }
         }
 
-        #endregion ITeleportHandler Implementation
+        #endregion ILocomotionServiceHandler Implementation
     }
 }

--- a/Runtime/Teleportation/TeleportInteractor.cs
+++ b/Runtime/Teleportation/TeleportInteractor.cs
@@ -391,6 +391,9 @@ namespace RealityToolkit.Locomotion.Teleportation
         #region ITeleportHandler Implementation
 
         /// <inheritdoc />
+        public void OnMoving(LocomotionEventData eventData) { }
+
+        /// <inheritdoc />
         public void OnTeleportTargetRequested(LocomotionEventData eventData)
         {
             // Only enable teleport if the request is addressed at our input source.


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

So far `ILocomotionHandler`s have only been notified about a teleportation happening but not free movement. This PR adds a moving event raised whenever free movement is happening, so developers can choose to perform actions upon movement.

This will also be useful in a future release to allow teleportation providers to know that movement is happening. This can be then used to cancel teleportation upon movement and such.

### Usage

### Method 1: Register a game object handler

```csharp
public class MovementHandler : MonoBehaviour, ILocomotionServiceHandler
{
    private void Awake()
    {
        ServiceManager.Instance.GetService<ILocomotionService>().Register(gameObject);
    }

    ...
}
```

### Method 2: Use C# event

```csharp
public class MovementHandler : MonoBehaviour, ILocomotionServiceHandler
{
    private void Awake()
    {
        ServiceManager.Instance.GetService<ILocomotionService>().Moving += LocomotionService_Moving;
    }

    ...
}
```