### PR TITLE
Fix exception where the enabled locomotion providers dictionary is changed while being looped

### DIFF
--- a/Runtime/Teleportation/BaseTeleportLocomotionProvider.cs
+++ b/Runtime/Teleportation/BaseTeleportLocomotionProvider.cs
@@ -56,7 +56,7 @@ namespace RealityToolkit.Locomotion.Teleportation
         protected Dictionary<uint, ITeleportTargetProvider> AvailableTargetProviders { get; } = new Dictionary<uint, ITeleportTargetProvider>();
 
         /// <inheritdoc />
-        public bool IsTeleporting { get; protected set; }
+        public bool IsTeleporting { get; private set; }
 
         protected override void OnDeactivated()
         {

--- a/Runtime/Teleportation/TeleportAnchor.cs
+++ b/Runtime/Teleportation/TeleportAnchor.cs
@@ -87,7 +87,7 @@ namespace RealityToolkit.Locomotion.Teleportation
 
             if (ServiceManager.Instance.TryGetService<ILocomotionService>(out var locomotionService))
             {
-                locomotionService.TeleportStarted += LocomotionService_TeleportStarted;
+                locomotionService.TeleportCompleted += LocomotionService_TeleportCompleted;
             }
         }
 
@@ -98,7 +98,7 @@ namespace RealityToolkit.Locomotion.Teleportation
         {
             if (ServiceManager.Instance.TryGetService<ILocomotionService>(out var locomotionService))
             {
-                locomotionService.TeleportStarted -= LocomotionService_TeleportStarted;
+                locomotionService.TeleportStarted -= LocomotionService_TeleportCompleted;
             }
 
             IsTargeted = false;
@@ -126,11 +126,11 @@ namespace RealityToolkit.Locomotion.Teleportation
             IsTargeted = false;
         }
 
-        private void LocomotionService_TeleportStarted(LocomotionEventData eventData)
+        private void LocomotionService_TeleportCompleted(LocomotionEventData eventData)
         {
-            if (eventData.Anchor != null &&
-                eventData.Anchor == (ITeleportAnchor)this)
+            if (eventData.Anchor != null && Equals(eventData.Anchor))
             {
+                onActivated?.Invoke();
                 Activated?.Invoke();
             }
         }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Discovered an edge case when changing the active teleport provider just right after a teleport has completed due to a dictionary being changed while being iterated.

Realized the enabled locomotion provider management was overly complicated anyways and refactored.

Also fixed the teleport anchor activated Unity event not being raised at all.